### PR TITLE
Update versions.tf

### DIFF
--- a/terraform_workshop_part_1/versions.tf
+++ b/terraform_workshop_part_1/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     openstack = {
-      source = "terraform-providers/openstack"
+      source = "terraform-provider-openstack/openstack"
     }
   }
   required_version = ">= 0.13"

--- a/terraform_workshop_part_2/versions.tf
+++ b/terraform_workshop_part_2/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     openstack = {
-      source = "terraform-providers/openstack"
+      source = "terraform-provider-openstack/openstack"
     }
   }
   required_version = ">= 0.13"

--- a/terraform_workshop_part_3/versions.tf
+++ b/terraform_workshop_part_3/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     openstack = {
-      source = "terraform-providers/openstack"
+      source = "terraform-provider-openstack/openstack"
     }
   }
   required_version = ">= 0.13"


### PR DESCRIPTION
to avoid the warning from terraform cli:

```Warning: Additional provider information from registry

The remote registry returned warnings for
registry.terraform.io/terraform-providers/openstack:
- For users on Terraform 0.13 or greater, this provider has moved to
terraform-provider-openstack/openstack. Please update your source in
required_providers.
```